### PR TITLE
Remove Patchelf workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+services: [docker]
+
+script:
+  - docker run -v $(pwd):$(pwd) -w $(pwd) snapcore/snapcraft:beta sh -c "apt update && snapcraft --version && snapcraft"
+  - sudo apt -q install --yes snapd
+  - sudo snap install *.snap --dangerous --classic
+  - /snap/bin/powershell -v

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Snapcrafters
+Copyright (c) 2017 Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,1 @@
+&"$PSScriptRoot/tools/releaseBuild/vstsbuild.ps1" -Name powershell-snap-latest

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,15 +44,15 @@ parts:
       file="./version.txt"
       if [ -f "$file" ]
       then
-        echo using version file
+        echo "using version file"
         version=$(cat $file)
       else
-        echo getting latest version from GitHub
+        echo "getting latest version from GitHub"
         version=$(curl -s 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json' | jq .ReleaseTag | sed 's/"//g' | sed 's/v//')
-        echo Writing version to file
+        echo "Writing version to file"
         echo $version > $file
       fi
-      echo getting powershell $version
+      echo "getting powershell $version"
       curl -L -o powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v$version/powershell-$version-linux-x64.tar.gz
     install: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/opt/powershell

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,13 +1,14 @@
 name: powershell
+
+# the version number is not used, but required
 version: 6.0.1
 version-script: |
   file="./version.txt"
   if [ -f "$file" ]
   then
-    cat ./version.txt
+    cat $file
   else
     version=$(curl -s 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json' | jq .ReleaseTag | sed 's/"//g' | sed 's/v//')
-    $version > ./version.txt
     echo $version
   fi
 summary: PowerShell for every system
@@ -40,7 +41,17 @@ parts:
     after: [scripts, patches]
     plugin: nil
     prepare: |
-      version=$(cat ./version.txt)
+      file="./version.txt"
+      if [ -f "$file" ]
+      then
+        echo using version file
+        version=$(cat $file)
+      else
+        echo getting latest version from GitHub
+        version=$(curl -s 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json' | jq .ReleaseTag | sed 's/"//g' | sed 's/v//')
+        echo Writing version to file
+        echo $version > $file
+      fi
       echo getting powershell $version
       curl -L -o powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v$version/powershell-$version-linux-x64.tar.gz
     install: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,3 +65,4 @@ parts:
       - zlib1g
     build-packages:
       - curl
+      - jq

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,15 +16,11 @@ description: |
   It consists of a cross-platform (Windows, Linux and macOS)
   command-line shell and associated scripting language.
 
-confinement: classic # use 'strict' once you have the right plugs and slots
+confinement: classic
 
 apps:
   powershell:
     command: opt/powershell/pwsh
-  # powershell:
-  #   command: bin/powershell-launch
-  # telemetry:
-  #   command: bin/powershell-telemetry
 
 parts:
   patches:
@@ -41,16 +37,12 @@ parts:
       '*': bin/
 
   powershell:
-    # after: [scripts]
-    # plugin: dump
-    # source: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell_6.0.0-1.ubuntu.16.04_amd64.deb
     after: [scripts, patches]
     plugin: nil
     prepare: |
       version=$(cat ./version.txt)
       echo getting powershell $version
       curl -L -o powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v$version/powershell-$version-linux-x64.tar.gz
-    # patch -Np1 < "$SNAPCRAFT_STAGE/telemetry.diff"
     install: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/opt/powershell
       tar zxf powershell.tar.gz -C $SNAPCRAFT_PART_INSTALL/opt/powershell

--- a/tools/releaseBuild/Images/GenericLinuxFiles/powershell-snap.ps1
+++ b/tools/releaseBuild/Images/GenericLinuxFiles/powershell-snap.ps1
@@ -22,6 +22,7 @@ if ($ReleaseTag)
 
 Push-Location
 try {
+    Write-Verbose "snapcraft version $(snapcraft --version)" -Verbose    
     Set-Location $location
     if($ReleaseTag)
     {
@@ -30,14 +31,8 @@ try {
         Write-Verbose "verify version..." -Verbose
         cat ./version.txt
     }
-    Write-Verbose "building prime..." -Verbose
-    snapcraft prime
-    # workaround for https://bugs.launchpad.net/snapcraft/+bug/1746329
-    patchelf --force-rpath --set-rpath '/snap/core/current/usr/lib/x86_64-linux-gnu:/snap/core/current/lib/x86_64-linux-gnu:/snap/powershell/current/usr/lib/x86_64-linux-gnu' ./prime/opt/powershell/pwsh
-    Write-Verbose "verify rpath..." -Verbose
-    patchelf --print-rpath ./prime/opt/powershell/pwsh
-    Write-Verbose "packing..." -Verbose
-    snapcraft pack prime
+    Write-Verbose "building snap..." -Verbose
+    snapcraft snap
 }
 finally
 {

--- a/tools/releaseBuild/Images/microsoft_powershell_ubuntu16.04/Dockerfile
+++ b/tools/releaseBuild/Images/microsoft_powershell_ubuntu16.04/Dockerfile
@@ -1,28 +1,33 @@
-# Docker image file that describes an Ubuntu16.04 image with PowerShell installed from Microsoft APT Repo
-FROM microsoft/powershell:ubuntu16.04
+# Docker image file that describes an Ubuntu16.04 image with PowerShell and SnapCraft installed from Microsoft APT Repo
+FROM snapcore/snapcraft:beta
 
-# change channel=beta on line 11 to stable when .38 becomes stable.
+# Install apt-utils (for apt-key used later)
+# Install ca-certificates so we can use ssl
+# Install curl, used later
+# install https for apt
+# install git used by snapcraft
 RUN apt-get update && \
-  apt-get dist-upgrade --yes && \
-  apt-get install --yes \
-  curl sudo jq squashfs-tools git patchelf && \
-  curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap && \
-  mkdir -p /snap/core && unsquashfs -d /snap/core/current core.snap && rm core.snap && \
-  curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=beta' | jq '.download_url' -r) --output snapcraft.snap && \
-  mkdir -p /snap/snapcraft && unsquashfs -d /snap/snapcraft/current snapcraft.snap && rm snapcraft.snap && \
-  mkdir -p /snap/bin && ln -s /snap/snapcraft/current/bin/snapcraft-classic /snap/bin/snapcraft && \
-  apt remove --yes --purge curl jq && \
-  apt-get autoclean --yes && \
-  apt-get clean --yes
-
-ENV SNAP=/snap/snapcraft/current
-ENV SNAP_NAME=snapcraft
-ENV SNAP_VERSION=beta
-ENV PATH=/snap/bin:$PATH
+    apt-get full-upgrade --yes && \
+    apt-get install -y --no-install-recommends \
+        apt-utils \
+        ca-certificates \
+        curl \
+        apt-transport-https \
+        git && \
+# Import the public repository GPG keys for Microsoft
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -  && \
+# Register the Microsoft Ubuntu 16.04 repository with apt
+    curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list && \
+# Update after register new repo
+    apt-get update && \
+# Install Powershell
+    apt-get install --yes \
+      powershell && \
+# Clean up so the layer is small
+    apt remove --yes --purge apt-utils apt-transport-https && \
+    apt-get autoclean --yes && \
+    apt-get clean --yes
 
 COPY powershell-snap.ps1 /powershell-snap.ps1
 COPY powershell-snap.sh /powershell-snap.sh
 RUN chmod u+x /powershell-snap.sh
-# Required by click.
-ENV LC_ALL C.UTF-8
-


### PR DESCRIPTION
Remove Patchelf workaround

Also:
    - Update docker file to use SnapCraft image now that image has a version that works
    - Update version code so that it works when `releasetag` is not specified
    - Declare dependency on `jq` so that build will work when not in docker