### PR TITLE
Fix dynamic library load issues

### DIFF
--- a/preview/launcher/powershell-wrapper
+++ b/preview/launcher/powershell-wrapper
@@ -5,4 +5,7 @@
 # Create $XDG_RUNTIME_DIR if it doesn't exist
 [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
 
+# .NET does some dynmanic loads and the only way we know of to change the location, is to set this variable
+export LD_LIBRARY_PATH="$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu/openssl-1.0.0/engines:$SNAP/usr/lib/x86_64-linux-gnu"
+
 exec "$SNAP/opt/powershell/pwsh" "$@"


### PR DESCRIPTION
Fixes #33 

# Notes

To find the location,
work around (`export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`) the issue and run `dir $pshome/../../lib*.so* -Recurse`