### PR TITLE
Add core18 to docker images

### DIFF
--- a/tools/releaseBuild/Images/microsoft_powershell_ubuntu16.04/Dockerfile
+++ b/tools/releaseBuild/Images/microsoft_powershell_ubuntu16.04/Dockerfile
@@ -17,6 +17,8 @@ RUN echo SNAPCRAFT_URL: ${SNAPCRAFT_URL} && \
     git && \
   curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap && \
   mkdir -p /snap/core && unsquashfs -d /snap/core/current core.snap && rm core.snap && \
+  curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap && \
+  mkdir -p /snap/core18 && unsquashfs -d /snap/core18/current core18.snap && rm core18.snap && \
   curl -L $(curl -H 'X-Ubuntu-Series: 16' ${SNAPCRAFT_URL} | jq '.download_url' -r) --output snapcraft.snap && \
   mkdir -p /snap/snapcraft && unsquashfs -d /snap/snapcraft/current snapcraft.snap && rm snapcraft.snap && \
   apt remove --yes --purge jq squashfs-tools && \

--- a/tools/releaseBuild/Images/microsoft_powershell_ubuntu18.04/Dockerfile
+++ b/tools/releaseBuild/Images/microsoft_powershell_ubuntu18.04/Dockerfile
@@ -15,10 +15,8 @@ RUN echo SNAPCRAFT_URL: ${SNAPCRAFT_URL} && \
     jq \
     squashfs-tools \
     git && \
-  curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap && \
-  mkdir -p /snap/core && unsquashfs -d /snap/core/current core.snap && rm core.snap && \
-#  curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap && \
-#  mkdir -p /snap/core18 && unsquashfs -d /snap/core18/current core18.snap && rm core18.snap && \
+  curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap && \
+  mkdir -p /snap/core18 && unsquashfs -d /snap/core18/current core18.snap && rm core18.snap && \
   curl -L $(curl -H 'X-Ubuntu-Series: 16' ${SNAPCRAFT_URL} | jq '.download_url' -r) --output snapcraft.snap && \
   mkdir -p /snap/snapcraft && unsquashfs -d /snap/snapcraft/current snapcraft.snap && rm snapcraft.snap && \
   apt remove --yes --purge jq squashfs-tools && \


### PR DESCRIPTION
The snapcraft tool now depends on core18 instead of core