### PR TITLE
Remove `libmi` dependencies to resolve crashes in snap packages

### DIFF
--- a/lts/snap/snapcraft.yaml
+++ b/lts/snap/snapcraft.yaml
@@ -78,6 +78,8 @@ parts:
       find $SNAPCRAFT_PART_INSTALL -type l -ls
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0
+      echo "removing libmi.so, it makes the snap unstable..."
+      rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libmi.so
       echo "removed old symlinks"
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0

--- a/lts/snap/snapcraft.yaml
+++ b/lts/snap/snapcraft.yaml
@@ -102,8 +102,6 @@ parts:
     stage-packages:
       - libicu60
       - liblttng-ust0
-      - libssl1.0.0
-      - libssl1.1
       - zlib1g
       - libc6
       - libgcc1

--- a/lts/snap/snapcraft.yaml
+++ b/lts/snap/snapcraft.yaml
@@ -78,8 +78,6 @@ parts:
       find $SNAPCRAFT_PART_INSTALL -type l -ls
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0
-      echo "removing libmi.so, it makes the snap unstable..."
-      rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libmi.so
       echo "removed old symlinks"
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0

--- a/preview/snap/snapcraft.yaml
+++ b/preview/snap/snapcraft.yaml
@@ -100,8 +100,6 @@ parts:
     stage-packages:
       - libicu60
       - liblttng-ust0
-      - libssl1.0.0
-      - libssl1.1
       - zlib1g
       - libc6
       - libgcc1

--- a/preview/snap/snapcraft.yaml
+++ b/preview/snap/snapcraft.yaml
@@ -76,6 +76,8 @@ parts:
       find $SNAPCRAFT_PART_INSTALL -type l -ls
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0
+      echo "removing libmi.so, it makes the snap unstable..."
+      rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libmi.so
       echo "removed old symlinks"
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0

--- a/preview/snap/snapcraft.yaml
+++ b/preview/snap/snapcraft.yaml
@@ -76,8 +76,6 @@ parts:
       find $SNAPCRAFT_PART_INSTALL -type l -ls
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0
-      echo "removing libmi.so, it makes the snap unstable..."
-      rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libmi.so
       echo "removed old symlinks"
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0

--- a/stable/snap/snapcraft.yaml
+++ b/stable/snap/snapcraft.yaml
@@ -2,18 +2,10 @@ name: powershell
 
 icon: assets/icon.png
 
-# the version number is not used, but required
-version: 6.0.1
-#base: core
-version-script: |
-  file="./version.txt"
-  if [ -f "$file" ]
-  then
-    cat $file
-  else
-    version=$(curl -s 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json' | jq .StableReleaseTag | sed 's/"//g' | sed 's/v//')
-    echo $version
-  fi
+grade: stable
+
+adopt-info: powershell-preview
+base: core18
 summary: PowerShell for every system!
 description: |
   PowerShell is an automation and configuration management platform.
@@ -27,6 +19,9 @@ confinement: classic
 apps:
   powershell:
     command: bin/powershell-wrapper
+    environment:
+      POWERSHELL_DISTRIBUTION_CHANNEL: PSSnap
+      CLR_ICU_VERSION_OVERRIDE: 60.2
 
 parts:
     # A wrapper script
@@ -42,6 +37,17 @@ parts:
   powershell:
     after: [launchers]
     plugin: nil
+    override-pull: |
+      snapcraftctl pull
+      file="./version.txt"
+      if [ -f "$file" ]
+      then
+        version=$(cat $file)
+      else
+        version=$(curl -s 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json' | jq .PreviewReleaseTag | sed 's/"//g' | sed 's/v//')
+      fi
+      snapcraftctl set-version "$version"
+      snapcraftctl set-grade "stable"
     override-build: |
       file="./version.txt"
       if [ -f "$file" ]
@@ -92,10 +98,12 @@ parts:
       done >> $thirdPartyNoticeFile
       echo "Done building third party notices file - $thirdPartyNoticeFile"
     stage-packages:
-      - libicu55
+      - libicu60
       - liblttng-ust0
-      - libssl1.0.0
       - zlib1g
+      - libc6
+      - libgcc1
+      - libstdc++6
     build-packages:
       - curl
       - jq

--- a/stable/snap/snapcraft.yaml
+++ b/stable/snap/snapcraft.yaml
@@ -76,6 +76,8 @@ parts:
       find $SNAPCRAFT_PART_INSTALL -type l -ls
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0
+      echo "removing libmi.so, it makes the snap unstable..."
+      rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libmi.so
       echo "removed old symlinks"
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0

--- a/stable/snap/snapcraft.yaml
+++ b/stable/snap/snapcraft.yaml
@@ -76,8 +76,6 @@ parts:
       find $SNAPCRAFT_PART_INSTALL -type l -ls
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0
-      echo "removing libmi.so, it makes the snap unstable..."
-      rm $SNAPCRAFT_PART_INSTALL/opt/powershell/libmi.so
       echo "removed old symlinks"
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libcrypto.so.1.0.0
       ln -sfn ../../usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 $SNAPCRAFT_PART_INSTALL/opt/powershell/libssl.so.1.0.0

--- a/stable/snap/snapcraft.yaml
+++ b/stable/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ icon: assets/icon.png
 
 grade: stable
 
-adopt-info: powershell-preview
+adopt-info: powershell
 base: core18
 summary: PowerShell for every system!
 description: |

--- a/tools/releaseBuild/build.json
+++ b/tools/releaseBuild/build.json
@@ -10,8 +10,8 @@
         "./tools/releaseBuild/Images/GenericLinuxFiles/powershell-snap.ps1",
         "./tools/releaseBuild/Images/GenericLinuxFiles/snapcraft-wrapper"
       ],
-      "DockerFile": "./tools/releaseBuild/Images/microsoft_powershell_ubuntu16.04/Dockerfile",
-      "DockerImageName": "ps-snap-ubunutu-16-04",
+      "DockerFile": "./tools/releaseBuild/Images/microsoft_powershell_ubuntu18.04/Dockerfile",
+      "DockerImageName": "ps-snap-ubunutu-18-04",
       "BinaryBucket": "stable",
       "EnableFeature": [ "ArtifactAsFolder" ]
     },
@@ -52,8 +52,8 @@
         "./tools/releaseBuild/Images/GenericLinuxFiles/powershell-snap.ps1",
         "./tools/releaseBuild/Images/GenericLinuxFiles/snapcraft-wrapper"
       ],
-      "DockerFile": "./tools/releaseBuild/Images/microsoft_powershell_ubuntu16.04/Dockerfile",
-      "DockerImageName": "ps-snap-ubunutu-16-04",
+      "DockerFile": "./tools/releaseBuild/Images/microsoft_powershell_ubuntu18.04/Dockerfile",
+      "DockerImageName": "ps-snap-ubunutu-18-04",
       "BinaryBucket": "release"
     },
     {


### PR DESCRIPTION
Fixes #52 

The `libmi` dependencies were causing a crash when loaded which resulted in a segfault.  Since, a newer version of `libmi` is not available, the only solution is to remove it.