### PR TITLE
preview/snap: fix rpath and remove libc6 stage package

### DIFF
--- a/preview/snap/snapcraft.yaml
+++ b/preview/snap/snapcraft.yaml
@@ -105,7 +105,6 @@ parts:
       - libicu60
       - liblttng-ust0
       - zlib1g
-      - libc6
       - libgcc1
       - libstdc++6
     build-packages:

--- a/preview/snap/snapcraft.yaml
+++ b/preview/snap/snapcraft.yaml
@@ -67,7 +67,11 @@ parts:
       mkdir -p $SNAPCRAFT_PART_INSTALL/opt/powershell
       tar zxf powershell.tar.gz -C $SNAPCRAFT_PART_INSTALL/opt/powershell
       echo 'updating rpath...'
-      patchelf --force-rpath --set-rpath '$ORIGIN/netcoredeps:$ORIGIN/../../usr/lib/x86_64-linux-gnu' $SNAPCRAFT_PART_INSTALL/opt/powershell/pwsh
+      current_rpath="$(patchelf --print-rpath $SNAPCRAFT_PART_INSTALL/opt/powershell/pwsh)"
+      append_rpath='$ORIGIN:$ORIGIN/../../usr/lib/x86_64-linux-gnu:$ORIGIN/../../lib/x86_64-linux-gnu'
+      new_rpath="${current_rpath}:${append_rpath}"
+      echo "set rpath: ${new_rpath}"
+      patchelf --force-rpath --set-rpath "${new_rpath}" $SNAPCRAFT_PART_INSTALL/opt/powershell/pwsh
       echo 'new rpath'
       patchelf --print-rpath $SNAPCRAFT_PART_INSTALL/opt/powershell/pwsh
       echo 'fixed rpath'


### PR DESCRIPTION
Powershell's dependencies use dlopen() to open various libraries.
As dlopen() will account for rpath, we need to ensure that all
libraries that need to be loaded by powershell are included.

Here we add the following paths to rpath:
- $ORIGIN
- $ORIGIN/../../usr/lib/x86_64-linux-gnu
- $ORIGIN/../../lib/x86_64-linux-gnu

Snapcraft will also append to the path to incorporate the paths
provided by the base (core18) snap.

This fixes running on Ubuntu 20.04.