### PR TITLE
Fix broken releases on newer Ubuntu systems

### DIFF
--- a/preview/snap/snapcraft.yaml
+++ b/preview/snap/snapcraft.yaml
@@ -104,6 +104,7 @@ parts:
       - zlib1g
       - libgcc1
       - libstdc++6
+      - libssl1.0.0
     build-packages:
       - curl
       - jq

--- a/stable/snap/snapcraft.yaml
+++ b/stable/snap/snapcraft.yaml
@@ -109,7 +109,7 @@ parts:
       - zlib1g
       - libgcc1
       - libstdc++6
-      - libssl.0.0
+      - libssl1.0.0
     build-packages:
       - curl
       - jq

--- a/stable/snap/snapcraft.yaml
+++ b/stable/snap/snapcraft.yaml
@@ -109,6 +109,7 @@ parts:
       - zlib1g
       - libgcc1
       - libstdc++6
+      - libssl.0.0
     build-packages:
       - curl
       - jq


### PR DESCRIPTION
Add `libssl` to stage-packages to fix missing library issues on newer Ubuntus

Fixes: powershell/powershell#15608
Fixes: powershell/powershell#15567
Fixes: powershell/powershell#15101
Fixes: powershell/powershell#15029

Maybe related: powershell/powershell#15702

Fixes: #75 