### PR TITLE
Change snapcraft to read base url from buildinfo

### DIFF
--- a/lts/snap/snapcraft.yaml
+++ b/lts/snap/snapcraft.yaml
@@ -52,26 +52,26 @@ parts:
       snapcraftctl set-grade "stable"
     override-build: |
       file="./version.txt"
+      buildinfo=$(curl -s -L https://aka.ms/pwsh-buildinfo-7-4)
+      baseurl=$(echo $buildinfo | jq -r .BaseUrl)
       if [ -f "$file" ]
       then
         echo "using version file"
         version=$(cat $file)
       else
         echo "getting latest version from GitHub"
-        version=$(curl -s -L https://aka.ms/pwsh-buildinfo-7-4| jq -r .ReleaseTag | sed 's/v//')
+        version=$(echo $buildinfo | jq -r .ReleaseTag | sed 's/v//')
         echo "Writing version to file"
         echo $version > $file
       fi
-      container=$(echo v$version| sed 's/\./-/g')
-      echo "getting powershell $version - $container"
-      # These urls are subject to change.
+      echo "getting powershell $version - $baseurl/v$version"
       case "$SNAPCRAFT_ARCH_TRIPLET" in
         aarch64-linux-gnu)
-          curl -L -o powershell.tar.gz https://pscoretestdata.blob.core.windows.net/$container/powershell-$version-linux-arm64.tar.gz ;;
+          curl -L -o powershell.tar.gz $baseurl/v$version/powershell-$version-linux-arm64.tar.gz ;;
         arm-linux-gnueabihf)
-          curl -L -o powershell.tar.gz https://pscoretestdata.blob.core.windows.net/$container/powershell-$version-linux-arm32.tar.gz ;;
+          curl -L -o powershell.tar.gz $baseurl/v$version/powershell-$version-linux-arm32.tar.gz ;;
         x86_64-linux-gnu)
-          curl -L -o powershell.tar.gz https://pscoretestdata.blob.core.windows.net/$container/powershell-$version-linux-x64.tar.gz ;;
+          curl -L -o powershell.tar.gz $baseurl/v$version/powershell-$version-linux-x64.tar.gz ;;
         *)
           # fail because we don't have a build for the requested platform
           echo "The $SNAPCRAFT_ARCH_TRIPLET platform does not have an available build. Exiting."

--- a/preview/snap/snapcraft.yaml
+++ b/preview/snap/snapcraft.yaml
@@ -50,26 +50,26 @@ parts:
       snapcraftctl set-grade "stable"
     override-build: |
       file="./version.txt"
+      buildinfo=$(curl -s -L https://aka.ms/pwsh-buildinfo-preview)
+      baseurl=$(echo $buildinfo | jq -r .BaseUrl)
       if [ -f "$file" ]
       then
         echo "using version file"
         version=$(cat $file)
       else
         echo "getting latest version from GitHub"
-        version=$(curl -s -L https://aka.ms/pwsh-buildinfo-preview | jq -r .ReleaseTag | sed 's/v//')
+        version=$(echo $buildinfo | jq -r .ReleaseTag | sed 's/v//')
         echo "Writing version to file"
         echo $version > $file
       fi
-      container=$(echo v$version| sed 's/\./-/g')
-      echo "getting powershell $version - $container"
-      # These urls are subject to change.
+      echo "getting powershell $version - $baseurl/v$version"
       case "$SNAPCRAFT_ARCH_TRIPLET" in
         aarch64-linux-gnu)
-          curl -L -o powershell.tar.gz https://pscoretestdata.blob.core.windows.net/$container/powershell-$version-linux-arm64.tar.gz ;;
+          curl -L -o powershell.tar.gz $baseurl/v$version/powershell-$version-linux-arm64.tar.gz ;;
         arm-linux-gnueabihf)
-          curl -L -o powershell.tar.gz https://pscoretestdata.blob.core.windows.net/$container/powershell-$version-linux-arm32.tar.gz ;;
+          curl -L -o powershell.tar.gz $baseurl/v$version/powershell-$version-linux-arm32.tar.gz ;;
         x86_64-linux-gnu)
-          curl -L -o powershell.tar.gz https://pscoretestdata.blob.core.windows.net/$container/powershell-$version-linux-x64.tar.gz ;;
+          curl -L -o powershell.tar.gz $baseurl/v$version/powershell-$version-linux-x64.tar.gz ;;
         *)
           # fail because we don't have a build for the requested platform
           echo "The $SNAPCRAFT_ARCH_TRIPLET platform does not have an available build. Exiting."

--- a/stable/snap/snapcraft.yaml
+++ b/stable/snap/snapcraft.yaml
@@ -52,26 +52,26 @@ parts:
       snapcraftctl set-grade "stable"
     override-build: |
       file="./version.txt"
+      buildinfo=$(curl -s -L https://aka.ms/pwsh-buildinfo-7-4)
+      baseurl=$(echo $buildinfo | jq -r .BaseUrl)
       if [ -f "$file" ]
       then
         echo "using version file"
         version=$(cat $file)
       else
         echo "getting latest version from GitHub"
-        version=$(curl -s -L https://aka.ms/pwsh-buildinfo-7-4| jq -r .ReleaseTag | sed 's/v//')
+        version=$(echo $buildinfo | jq -r .ReleaseTag | sed 's/v//')
         echo "Writing version to file"
         echo $version > $file
       fi
-      container=$(echo v$version| sed 's/\./-/g')
-      echo "getting powershell $version - $container"
-      # These urls are subject to change.
+      echo "getting powershell $version - $baseurl/v$version"
       case "$SNAPCRAFT_ARCH_TRIPLET" in
         aarch64-linux-gnu)
-          curl -L -o powershell.tar.gz https://pscoretestdata.blob.core.windows.net/$container/powershell-$version-linux-arm64.tar.gz ;;
+          curl -L -o powershell.tar.gz $baseurl/v$version/powershell-$version-linux-arm64.tar.gz ;;
         arm-linux-gnueabihf)
-          curl -L -o powershell.tar.gz https://pscoretestdata.blob.core.windows.net/$container/powershell-$version-linux-arm32.tar.gz ;;
+          curl -L -o powershell.tar.gz $baseurl/v$version/powershell-$version-linux-arm32.tar.gz ;;
         x86_64-linux-gnu)
-          curl -L -o powershell.tar.gz https://pscoretestdata.blob.core.windows.net/$container/powershell-$version-linux-x64.tar.gz ;;
+          curl -L -o powershell.tar.gz $baseurl/v$version/powershell-$version-linux-x64.tar.gz ;;
         *)
           # fail because we don't have a build for the requested platform
           echo "The $SNAPCRAFT_ARCH_TRIPLET platform does not have an available build. Exiting."


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use the new `BaseUrl` field in the buildinfo to determine the URL to download from. I don't really understand the point of the `version.txt` file still, but I preserved the logic just in case it's needed.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
